### PR TITLE
Allow recent kaminari_route_prefix (1-7-stable)

### DIFF
--- a/curation_concerns.gemspec
+++ b/curation_concerns.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'hydra-editor', '>= 2', '< 4'
   spec.add_dependency 'rails_autolink'
   spec.add_dependency 'sprockets-es6'
-  spec.add_dependency 'kaminari_route_prefix', '~> 0.0.1'
+  spec.add_dependency 'kaminari_route_prefix', "< 2"
   spec.add_dependency 'active_attr'
   spec.add_dependency 'hydra-works', '>= 0.14.0'
   spec.add_dependency 'active_fedora-noid', '~> 2.0.0.beta5'


### PR DESCRIPTION
Which will then allow kaminari 1.0.

Not sure what the requirement should actually be, so I just said <2, figuring
eventually kaminari_route_prefix 1.0 is likely to be backwards compat with
current (already in production in many apps) 0.1.1

PR'd to 1-7-stable for 1.7.8 release with this relaxation.